### PR TITLE
Use engweb's header for auth

### DIFF
--- a/datahub-frontend/app/controllers/Application.java
+++ b/datahub-frontend/app/controllers/Application.java
@@ -42,6 +42,8 @@ public class Application extends Controller {
 
   private final Config _config;
   private final StandaloneWSClient _ws;
+  @Inject
+  private  AuthenticationController authenticationController;
 
   @Inject
   public Application(@Nonnull Config config) {
@@ -76,7 +78,13 @@ public class Application extends Controller {
    */
   @Nonnull
   public Result index(@Nullable String path) {
-    return serveAsset("");
+    if("login".equalsIgnoreCase(path)) {
+      return serveAsset(path);
+    }
+    if(hasValidSessionCookie(ctx())) {
+      return serveAsset("");
+    }
+    return authenticationController.authenticate();
   }
 
   /**

--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --no-cache --update-cache --available upgrade \
 ARG ENABLE_EMBER="false"
 ARG USE_SYSTEM_NODE="true"
 ENV CI=true
-ENV GRADLE_OPTS="-Xms256m -Xmx512m"
+ENV GRADLE_OPTS="-Xms4G -Xmx4G"
 COPY . datahub-src
 RUN cd datahub-src && ./gradlew :datahub-frontend:dist -PenableEmber=${ENABLE_EMBER} -PuseSystemNode=${USE_SYSTEM_NODE} -x test -x yarnTest -x yarnLint \
     && cp datahub-frontend/build/distributions/datahub-frontend.zip ../datahub-frontend.zip \


### PR DESCRIPTION
This PR modifies authentication logic in datahub-frontend micro-service to use mail header in request from `engweb` to setup the HTTP session. [Corresponding PR](https://github.com/liftoffio/liftoff/pull/18053) in liftoff repository has more details.

Deploy plan:

- [x] Build a new docker image `liftoff-datahub-frontend-react`.
- [x] Modify docker compose in `exp/datahub` to use the new image.